### PR TITLE
correct README logging title example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ytdl("http://www.youtube.com/watch?v=aqz-KE-bpKQ").pipe(require("fs").createWrit
 
 // Get video info
 ytdl.getBasicInfo("http://www.youtube.com/watch?v=aqz-KE-bpKQ").then(info => {
-  console.log(info.title);
+  console.log(info.videoDetails.title);
 });
 
 // Get video info with download formats


### PR DESCRIPTION
it appears videoInfo was updated to move title into videoDetails without the readme being changed to reflect this.

I have tested this code on my machine using the latest version of `@distube/ytdl-core` with success; simply using info.title threw an error that the property does not exist on type `videoInfo`

test code:
```ts
  const url = "http://www.youtube.com/watch?v=aqz-KE-bpKQ";

  const basicVideoInfo = await ytdl.getBasicInfo(url)
  const videoTitle = basicVideoInfo.videoDetails.title

console.log("videoTitle", videoTitle) // Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film
  ```