### PR TITLE
Rearrangement of getInfo with multiple clients.

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -208,6 +208,20 @@ const parseFormats = player_response => {
   return formats;
 };
 
+const parseAdditionalManifests = (player_response, options) => {
+  let streamingData = player_response && player_response.streamingData,
+      manifests = [];
+  if (streamingData) {
+    if (streamingData.dashManifestUrl) {
+      manifests.push(getDashManifest(streamingData.dashManifestUrl, options));
+    }
+    if (streamingData.hlsManifestUrl) {
+      manifests.push(getM3U8(streamingData.hlsManifestUrl, options));
+    }
+  }
+  return manifests;
+}
+
 // TODO: Clean up this function for readability and support more clients
 /**
  * Gets info from a video additional formats and deciphered URLs.
@@ -223,51 +237,40 @@ exports.getInfo = async(id, options) => {
   utils.applyOldLocalAddress(options);
   const info = await exports.getBasicInfo(id, options);
   let funcs = [];
+
+  // Fill in HTML5 player URL
+  info.html5player = info.html5player ||
+    getHTML5player(await getWatchHTMLPageBody(id, options)) || getHTML5player(await getEmbedPageBody(id, options));
+
+  if (!info.html5player) {
+    throw Error('Unable to find html5player file');
+  }
+
+  const html5player = new URL(info.html5player, BASE_URL).toString();
+
+
   try {
     if (info.videoDetails.age_restricted) throw Error('Cannot download age restricted videos with mobile clients');
-    const [iosPlayerResponse, androidPlayerResponse] = await Promise.all([
+    const responses = await Promise.allSettled([
+      fetchWebCreatorPlayer(id, html5player, options),
       fetchIosJsonPlayer(id, options),
-      fetchAndroidJsonPlayer(id, options),
+      fetchAndroidJsonPlayer(id, options)
     ]);
-    info.formats = parseFormats(androidPlayerResponse).concat(parseFormats(iosPlayerResponse));
-    if (info.formats.length) {
-      funcs.push(info.formats);
-    }
-    if (androidPlayerResponse && androidPlayerResponse.streamingData) {
-      if (androidPlayerResponse.streamingData.dashManifestUrl) {
-        funcs.push(getDashManifest(androidPlayerResponse.streamingData.dashManifestUrl, options));
-      }
-      if (androidPlayerResponse.streamingData.hlsManifestUrl) {
-        funcs.push(getM3U8(androidPlayerResponse.streamingData.hlsManifestUrl, options));
-      }
-    }
-    if (iosPlayerResponse && iosPlayerResponse.streamingData) {
-      if (iosPlayerResponse.streamingData.dashManifestUrl) {
-        funcs.push(getDashManifest(iosPlayerResponse.streamingData.dashManifestUrl, options));
-      }
-      if (iosPlayerResponse.streamingData.hlsManifestUrl) {
-        funcs.push(getM3U8(iosPlayerResponse.streamingData.hlsManifestUrl, options));
+    info.formats = [].concat(...responses.map(r => parseFormats(r.value)));
+    if (info.formats.length === 0) throw new Error('Player JSON API failed');
+
+    funcs.push(sig.decipherFormats(info.formats, html5player, options));
+
+    for (let resp of responses) {
+      if (resp.value) {
+        funcs.push(...parseAdditionalManifests(resp.value, options));
       }
     }
   } catch (_) {
+    console.warn('error in player API; falling back to web-scraping')
     // Bring back web-scraping for now. TODO: tv client
-    info.html5player = info.html5player ||
-      getHTML5player(await getWatchHTMLPageBody(id, options)) || getHTML5player(await getEmbedPageBody(id, options));
-    if (!info.html5player) {
-      throw Error('Unable to find html5player file');
-    }
-    const html5player = new URL(info.html5player, BASE_URL).toString();
     funcs.push(sig.decipherFormats(parseFormats(info.player_response), html5player, options));
-    if (info.player_response && info.player_response.streamingData) {
-      if (info.player_response.streamingData.dashManifestUrl) {
-        let url = info.player_response.streamingData.dashManifestUrl;
-        funcs.push(getDashManifest(url, options));
-      }
-      if (info.player_response.streamingData.hlsManifestUrl) {
-        let url = info.player_response.streamingData.hlsManifestUrl;
-        funcs.push(getM3U8(url, options));
-      }
-    }
+    funcs.push(...parseAdditionalManifests(info.player_response));
   }
 
   let results = await Promise.all(funcs);
@@ -278,6 +281,73 @@ exports.getInfo = async(id, options) => {
   info.full = true;
   return info;
 };
+
+const getPlaybackContext = async (html5player, options) => {
+  const body = await utils.request(html5player, options);
+  let mo = body.match(/signatureTimestamp:(\d+)/);
+
+  return {
+    contentPlaybackContext: {
+      html5Preference: "HTML5_PREF_WANTS",
+      signatureTimestamp: mo ? mo[1] : undefined
+    }
+  };
+}
+
+const LOCALE = {"hl": "en", "timeZone": "UTC", "utcOffsetMinutes": 0},
+      CHECK_FLAGS = {contentCheckOk: true, racyCheckOk: true};
+
+const WEB_CREATOR_CONTEXT = {
+  client: {
+    clientName: "WEB_CREATOR",
+    clientVersion: "1.20240723.03.00",
+    ...LOCALE
+  }
+};
+
+const fetchWebCreatorPlayer = async (videoId, html5player, options) => {
+  
+  const payload = {
+    context: WEB_CREATOR_CONTEXT,
+    videoId, 
+    playbackContext: await getPlaybackContext(html5player, options),
+    ...CHECK_FLAGS
+  };
+
+  return await playerAPI(videoId, payload, undefined, options);
+}
+
+const playerAPI = async (videoId, payload, userAgent, options) => {
+
+  const { jar, dispatcher } = options.agent;
+  const opts = {
+    requestOptions: {
+      method: 'POST',
+      dispatcher,
+      query: {
+        prettyPrint: false,
+        t: utils.generateClientPlaybackNonce(12),
+        id: videoId,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: jar.getCookieStringSync('https://www.youtube.com'),
+        'User-Agent': userAgent,
+        'X-Goog-Api-Format-Version': '2',
+      },
+      body: JSON.stringify(payload),
+    },
+  };
+  const response = await utils.request('https://youtubei.googleapis.com/youtubei/v1/player', opts);
+  const playErr = utils.playError(response);
+  if (playErr) throw playErr;
+  if (!response.videoDetails || videoId !== response.videoDetails.videoId) {
+    const err = new Error('Malformed response from YouTube');
+    err.response = response;
+    throw err;
+  }
+  return response;
+}
 
 const IOS_CLIENT_VERSION = '19.28.1',
   IOS_DEVICE_MODEL = 'iPhone16,2',


### PR DESCRIPTION
Following up on this:
https://github.com/distubejs/ytdl-core/blob/ba9b3e92042ceccc10b0874a5fdc866f7ed90c09/lib/info.js#L211

Slightly refactored `getInfo` to reduce duplication. The treatment of iOS, Android, and Web clients is slightly unified. Also, added the "Web Creator" client, inspired by the defaults in https://github.com/yt-dlp/yt-dlp.