### PR TITLE
Added `rewriteRequest` Option to Enhance Request Flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .DS_Store
 .idea/*
 yarn.lock
+package-lock.json

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,7 +174,14 @@ exports.playError = player_response => {
 
 // Undici request
 exports.request = async(url, options = {}) => {
-  const { requestOptions } = options;
+  let { requestOptions, rewriteRequest } = options;
+
+  if (typeof rewriteRequest === "function") {
+    const request = rewriteRequest(url, requestOptions);
+    requestOptions = request.requestOptions;
+    url = request.url;
+  }
+  
   const req = await request(url, requestOptions);
   const code = req.statusCode.toString();
   if (code.startsWith('2')) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -340,6 +340,7 @@ declare module '@distube/ytdl-core' {
     interface getInfoOptions {
       lang?: string;
       requestCallback?: () => {};
+      rewriteRequest?: (url: string, requestOptions?: Parameters<typeof request>[1]) => {url: string, requestOptions?: Parameters<typeof request>[1]};
       requestOptions?: Parameters<typeof request>[1];
       agent?: Agent;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -340,7 +340,7 @@ declare module '@distube/ytdl-core' {
     interface getInfoOptions {
       lang?: string;
       requestCallback?: () => {};
-      rewriteRequest?: (url: string, requestOptions?: Parameters<typeof request>[1]) => {url: string, requestOptions?: Parameters<typeof request>[1]};
+      rewriteRequest?: (url: string, requestOptions: Parameters<typeof request>[1]) => {url: string, requestOptions: Parameters<typeof request>[1]};
       requestOptions?: Parameters<typeof request>[1];
       agent?: Agent;
     }


### PR DESCRIPTION
I’ve added a `rewriteRequest` option to the `request` function, which allows users to modify the URL and request options dynamically before making the request. This could be useful in cases where the request needs to be adjusted on the fly, such as adding custom query parameters or modifying headers.

Here’s a summary of what I’ve changed:
- Added a `rewriteRequest` function that, if provided, allows for the alteration of the request options and URL before the request is made.