### PR TITLE
Custom fetch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ You can find the API documentation in the [original repo](https://github.com/fen
 - `requestOptions` is now `undici`'s [`RequestOptions`](https://github.com/nodejs/undici#undicirequesturl-options-promise).
 - `agent`: [`ytdl.Agent`](https://github.com/distubejs/ytdl-core/blob/master/typings/index.d.ts#L10-L14)
 - `playerClients`: An array of player clients to use. Accepts `WEB`, `WEB_CREATOR`, `IOS`, and `ANDROID`. Defaults to `["WEB_CREATOR", "IOS"]`.
+- `fetch`: Custom fetch implementation. Defaults to `undici`'s request.
 
 ### `ytdl.createAgent([cookies]): ytdl.Agent`
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,22 +177,45 @@ exports.playError = player_response => {
 };
 
 // Undici request
-exports.request = async (url, options = {}) => {
-  let { requestOptions, rewriteRequest } = options;
-
-  if (typeof rewriteRequest === "function") {
-    const request = rewriteRequest(url, requestOptions);
-    requestOptions = request.requestOptions;
-    url = request.url;
+const useFetch = async (fetch, url, requestOptions) => {
+  // embed query to url
+  const query = requestOptions.query;
+  if (query) {
+    const urlObject = new URL(url);
+    for (const key in query) {
+      urlObject.searchParams.append(key, query[key]);
+    }
+    url = urlObject.toString();
   }
 
-  const req = await request(url, requestOptions);
+  const response = await fetch(url, requestOptions);
+
+  // convert webstandard response to undici request's response
+  const statusCode = response.status;
+  const body = Object.assign(response, response.body || {});
+  const headers = Object.fromEntries(response.headers.entries());
+
+  return { body, statusCode, headers };
+};
+exports.request = async (url, options = {}) => {
+  let { requestOptions, rewriteRequest, fetch } = options;
+
+  if (typeof rewriteRequest === "function") {
+    const rewritten = rewriteRequest(url, requestOptions);
+    requestOptions = rewritten.requestOptions || requestOptions;
+    url = rewritten.url || url;
+  }
+
+  const req =
+    typeof fetch === "function" ? await useFetch(fetch, url, requestOptions) : await request(url, requestOptions);
   const code = req.statusCode.toString();
+
   if (code.startsWith("2")) {
     if (req.headers["content-type"].includes("application/json")) return req.body.json();
     return req.body.text();
   }
   if (code.startsWith("3")) return exports.request(req.headers.location, options);
+
   const e = new Error(`Status code: ${code}`);
   e.statusCode = req.statusCode;
   throw e;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -351,6 +351,7 @@ declare module "@distube/ytdl-core" {
         url: string,
         requestOptions: Parameters<typeof request>[1],
       ) => { url: string; requestOptions: Parameters<typeof request>[1] };
+      fetch?: (url: string, requestOptions: Parameters<typeof request>[1]) => Promise<Response>;
       requestOptions?: Parameters<typeof request>[1];
       agent?: Agent;
       playerClients?: Array<"WEB_CREATOR" | "IOS" | "ANDROID" | "WEB">;


### PR DESCRIPTION
This PR introduces a custom fetch implementation to enhance flexibility and compatibility in handling HTTP requests.

- Added support for custom `fetch` function.
- Converts Web Standard `Response` objects to `Undici.Response` for compatibility.
- Leverages `Undici.request` when no custom fetch function is provided.

**Why This Change?**  
This custom implementation provides the following benefits:
- **Flexibility**: Developers can use their preferred fetch implementation (e.g., `node-fetch`, `isomorphic-fetch`, etc.).
- **Improved Developer Experience**: Simplifies HTTP request and response handling while maintaining robust error handling.