### PR TITLE
Correctly pass "agent" field for miniget which uses node http library and not undici

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,4 +1,5 @@
 const { ProxyAgent } = require("undici");
+const { HttpsProxyAgent } = require("https-proxy-agent");
 const { Cookie, CookieJar, canonicalDomain } = require("tough-cookie");
 const { CookieAgent, CookieClient } = require("http-cookie-agent/undici");
 
@@ -94,7 +95,14 @@ exports.createProxyAgent = (options, cookies = []) => {
     },
     options,
   );
-  return { dispatcher: new ProxyAgent(proxyOptions), jar, localAddress: options.localAddress };
+
+  // ProxyAgent type that node httplibrary supports
+  const agent = new HttpsProxyAgent(options.uri);
+
+  // ProxyAgent type that undici supports
+  const dispatcher = new ProxyAgent(proxyOptions);
+
+  return { dispatcher, agent, jar, localAddress: options.localAddress };
 };
 
 exports.defaultAgent = createAgent();

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,11 @@ const downloadFromInfoCallback = (stream, info, options) => {
       localAddress: utils.getRandomIPv6(options.IPv6Block),
     });
   }
+
   if (options.agent) {
+    // Set agent on both the miniget and m3u8stream requests
+    options.requestOptions.agent = options.agent.agent;
+
     if (options.agent.jar) {
       utils.setPropInsensitive(
         options.requestOptions.headers,
@@ -129,6 +133,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
       chunkReadahead: +info.live_chunk_readahead,
       begin: options.begin || (format.isLive && Date.now()),
       liveBuffer: options.liveBuffer,
+      // Now we have passed not only custom "dispatcher" with undici ProxyAgent, but also "agent" field which is compatible for node http
       requestOptions: options.requestOptions,
       parser: format.isDashMPD ? "dash-mpd" : "m3u8",
       id: format.itag,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "http-cookie-agent": "^6.0.6",
+    "https-proxy-agent": "^7.0.5",
     "m3u8stream": "^0.8.6",
     "miniget": "^4.2.3",
     "sax": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       http-cookie-agent:
         specifier: ^6.0.6
         version: 6.0.6(tough-cookie@4.1.4)(undici@5.28.4)
+      https-proxy-agent:
+        specifier: ^7.0.5
+        version: 7.0.5
       m3u8stream:
         specifier: ^0.8.6
         version: 0.8.6
@@ -68,6 +71,10 @@ packages:
     peerDependenciesMeta:
       undici:
         optional: true
+
+  https-proxy-agent@7.0.5:
+    resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
+    engines: {node: '>= 14'}
 
   m3u8stream@0.8.6:
     resolution: {integrity: sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==}
@@ -148,6 +155,13 @@ snapshots:
       tough-cookie: 4.1.4
     optionalDependencies:
       undici: 5.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.5:
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Currently http proxies doesn't work because this library uses undici http proxy agent for all requests, but when it's time to fetch video chunks from m3u8 file, it uses m3u8stream library. this library internally uses miniget library which uses standard node http library and another type for http proxy agents. Because of this, passed options with configured proxy agent is not compatible and m3u8stream doesn't use proxy for videos fetching.

So in this pull request we create and use http proxy agent which is supported by node http library and pass it into m3u8stream call.