### PR TITLE
Add support for TV client

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -251,23 +251,30 @@ exports.getInfo = async (id, options) => {
     throw Error("Unable to find html5player file");
   }
 
-  const html5player = new URL(info.html5player, BASE_URL).toString();
+  info.html5player = new URL(info.html5player, BASE_URL).toString();
 
   try {
     if (options.playerClients.includes("WEB")) {
-      funcs.push(sig.decipherFormats(parseFormats(info.player_response), html5player, options));
+      funcs.push(sig.decipherFormats(parseFormats(info.player_response), info.html5player, options));
       funcs.push(...parseAdditionalManifests(info.player_response));
     }
     if (info.videoDetails.age_restricted) throw Error("Cannot download age restricted videos with mobile clients");
     const promises = [];
-    if (options.playerClients.includes("WEB_CREATOR")) promises.push(fetchWebCreatorPlayer(id, html5player, options));
+    if (options.playerClients.includes("WEB_CREATOR")) promises.push(fetchWebCreatorPlayer(id, info, options));
+    if (options.playerClients.includes("TV")) promises.push(fetchTvPlayer(id, info, options));
     if (options.playerClients.includes("IOS")) promises.push(fetchIosJsonPlayer(id, options));
     if (options.playerClients.includes("ANDROID")) promises.push(fetchAndroidJsonPlayer(id, options));
     const responses = await Promise.allSettled(promises);
+
+    // warn about errors in player API calls
+    for (let r of responses)
+      if (r.status === 'rejected')  /** @todo mention which ones failed */
+        console.warn('Player JSON API failed:', r.reason);
+
     info.formats = [].concat(...responses.map(r => parseFormats(r.value)));
     if (info.formats.length === 0) throw new Error("Player JSON API failed");
 
-    funcs.push(sig.decipherFormats(info.formats, html5player, options));
+    funcs.push(sig.decipherFormats(info.formats, info.html5player, options));
 
     for (let resp of responses) {
       if (resp.value) {
@@ -297,6 +304,18 @@ const getPlaybackContext = async (html5player, options) => {
   };
 };
 
+const getVisitorData = (info, _options) => {
+  for (let respKey of ['player_response', 'response']) {
+    try {
+      return info[respKey].responseContext.serviceTrackingParams
+          .find(x => x.service === 'GFEEDBACK').params
+          .find(x => x.key === 'visitor_data').value;
+    }
+    catch { /* not present */ }
+  }
+  return undefined;
+}
+
 const LOCALE = { hl: "en", timeZone: "UTC", utcOffsetMinutes: 0 },
   CHECK_FLAGS = { contentCheckOk: true, racyCheckOk: true };
 
@@ -308,18 +327,39 @@ const WEB_CREATOR_CONTEXT = {
   },
 };
 
-const fetchWebCreatorPlayer = async (videoId, html5player, options) => {
+const TVHTML5_CONTEXT = {
+  client: {
+    clientName: "TVHTML5",
+    "clientVersion": "7.20241201.18.00",
+    ...LOCALE
+  }
+};
+
+const fetchWebCreatorPlayer = async (videoId, info, options) => {
   const payload = {
     context: WEB_CREATOR_CONTEXT,
     videoId,
-    playbackContext: await getPlaybackContext(html5player, options),
+    playbackContext: await getPlaybackContext(info.html5player, options),
     ...CHECK_FLAGS,
   };
 
-  return await playerAPI(videoId, payload, undefined, options);
+  return await playerAPI(videoId, payload, options);
 };
 
-const playerAPI = async (videoId, payload, userAgent, options) => {
+const fetchTvPlayer = async (videoId, info, options) => {
+  const payload = {
+    context: TVHTML5_CONTEXT,
+    videoId,
+    playbackContext: await getPlaybackContext(info.html5player, options),
+    ...CHECK_FLAGS,
+  };
+
+  options.requestOptions.headers['X-Goog-Visitor-Id'] = getVisitorData(info);
+
+  return await playerAPI(videoId, payload, options);
+};
+
+const playerAPI = async (videoId, payload, options) => {
   const { jar, dispatcher } = options.agent;
   const opts = {
     requestOptions: {
@@ -332,9 +372,9 @@ const playerAPI = async (videoId, payload, userAgent, options) => {
       },
       headers: {
         "Content-Type": "application/json",
-        cookie: jar.getCookieStringSync("https://www.youtube.com"),
-        "User-Agent": userAgent,
+        "Cookie": jar.getCookieStringSync("https://www.youtube.com"),
         "X-Goog-Api-Format-Version": "2",
+        ...options.requestOptions.headers
       },
       body: JSON.stringify(payload),
     },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -353,7 +353,7 @@ declare module "@distube/ytdl-core" {
       ) => { url: string; requestOptions: Parameters<typeof request>[1] };
       requestOptions?: Parameters<typeof request>[1];
       agent?: Agent;
-      playerClients?: Array<"WEB_CREATOR" | "IOS" | "ANDROID" | "WEB">;
+      playerClients?: Array<"WEB_CREATOR" | "TV" | "IOS" | "ANDROID" | "WEB">;
     }
 
     interface chooseFormatOptions {


### PR DESCRIPTION
This is based on the extraction logic in [yt-dlp](https://github.com/yt-dlp/yt-dlp).

Since `WEB_CREATOR` now requires a sign-in, perhaps it is worth considering replacing it with `TV` in the defaults.