### PR TITLE
Fix Autocomplete

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -365,7 +365,7 @@ declare module "@distube/ytdl-core" {
         | "lowestaudio"
         | "highestvideo"
         | "lowestvideo"
-        | string
+        | (string & {})
         | number
         | string[]
         | number[];


### PR DESCRIPTION
For typescript adding `string` with `"text"` will simply ignore `"text"`. Replacing `string` with `(string & {})` will force TypeScript to differentiate between literal strings and generic strings.