### PR TITLE
fix: add visitor data (#211)

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -427,6 +427,7 @@ const playerAPI = async (videoId, payload, options) => {
       body: JSON.stringify(payload),
     },
   };
+  if (options.visitorId) opts.requestOptions.headers["X-Goog-Visitor-Id"] = options.visitorId;
   const response = await utils.request("https://youtubei.googleapis.com/youtubei/v1/player", opts);
   const playErr = utils.playError(response);
   if (playErr) throw playErr;

--- a/lib/info.js
+++ b/lib/info.js
@@ -93,7 +93,7 @@ const getEmbedPageBody = (id, options) => {
 };
 
 const getHTML5player = body => {
-  let html5playerRes =
+  const html5playerRes =
     /<script\s+src="([^"]+)"(?:\s+type="text\/javascript")?\s+name="player_ias\/base"\s*>|"jsUrl":"([^"]+)"/.exec(body);
   return html5playerRes?.[1] || html5playerRes?.[2];
 };
@@ -122,7 +122,7 @@ const retryFunc = async (func, args, options) => {
       break;
     } catch (err) {
       if (err?.statusCode < 500 || currentTry >= options.maxRetries) throw err;
-      let wait = Math.min(++currentTry * options.backoff.inc, options.backoff.max);
+      const wait = Math.min(++currentTry * options.backoff.inc, options.backoff.max);
       await new Promise(resolve => setTimeout(resolve, wait));
     }
   }
@@ -144,7 +144,7 @@ const parseJSON = (source, varName, json) => {
 };
 
 const findJSON = (source, varName, body, left, right, prependJSON) => {
-  let jsonStr = utils.between(body, left, right);
+  const jsonStr = utils.between(body, left, right);
   if (!jsonStr) {
     throw Error(`Could not find ${varName} in ${source}`);
   }
@@ -159,8 +159,8 @@ const findPlayerResponse = (source, info) => {
 };
 
 const getWatchHTMLPage = async (id, options) => {
-  let body = await getWatchHTMLPageBody(id, options);
-  let info = { page: "watch" };
+  const body = await getWatchHTMLPageBody(id, options);
+  const info = { page: "watch" };
   try {
     try {
       info.player_response =
@@ -201,7 +201,7 @@ const parseFormats = player_response => {
 };
 
 const parseAdditionalManifests = (player_response, options) => {
-  let streamingData = player_response?.streamingData,
+  const streamingData = player_response?.streamingData,
     manifests = [];
   if (streamingData) {
     if (streamingData.dashManifestUrl) {
@@ -328,9 +328,9 @@ exports.getInfo = async (id, options) => {
     }
     
     if (!enhancedFormat.isHLS && enhancedFormat.mimeType &&
-        (enhancedFormat.mimeType.includes('hls') ||
-         enhancedFormat.mimeType.includes('x-mpegURL') ||
-         enhancedFormat.mimeType.includes('application/vnd.apple.mpegurl'))) {
+        (enhancedFormat.mimeType.includes("hls") ||
+         enhancedFormat.mimeType.includes("x-mpegURL") ||
+         enhancedFormat.mimeType.includes("application/vnd.apple.mpegurl"))) {
       enhancedFormat.isHLS = true;
     }
     
@@ -362,6 +362,18 @@ const getPlaybackContext = async (html5player, options) => {
       signatureTimestamp: mo?.[2],
     },
   };
+};
+
+const getVisitorData = (info, _options) => {
+  for (const respKey of ["player_response", "response"]) {
+    try {
+      return info[respKey].responseContext.serviceTrackingParams
+          .find(x => x.service === "GFEEDBACK").params
+          .find(x => x.key === "visitor_data").value;
+    }
+    catch { /* not present */ }
+  }
+  return undefined;
 };
 
 const LOCALE = { hl: "en", timeZone: "UTC", utcOffsetMinutes: 0 },
@@ -399,6 +411,9 @@ const fetchTvPlayer = async (videoId, info, options) => {
     playbackContext: await getPlaybackContext(info.html5player, options),
     ...CHECK_FLAGS,
   };
+
+  options.visitorId = getVisitorData(info, options);
+
   return await playerAPI(videoId, payload, options);
 };
 
@@ -417,6 +432,7 @@ const playerAPI = async (videoId, payload, options) => {
         "Content-Type": "application/json",
         Cookie: jar.getCookieStringSync("https://www.youtube.com"),
         "X-Goog-Api-Format-Version": "2",
+        "X-Goog-Visitor-Id": options.visitorId,
       },
       body: JSON.stringify(payload),
     },
@@ -571,7 +587,7 @@ const fetchAndroidJsonPlayer = async (videoId, options) => {
  */
 const getDashManifest = (url, options) =>
   new Promise((resolve, reject) => {
-    let formats = {};
+    const formats = {};
     const parser = sax.parser(false);
     parser.onerror = reject;
     let adaptationSet;
@@ -623,7 +639,7 @@ const getDashManifest = (url, options) =>
 const getM3U8 = async (url, options) => {
   url = new URL(url, BASE_URL);
   const body = await utils.request(url.toString(), options);
-  let formats = {};
+  const formats = {};
   body
     .split("\n")
     .filter(line => /^https?:\/\//.test(line))
@@ -636,7 +652,7 @@ const getM3U8 = async (url, options) => {
 
 // Cache get info functions.
 // In case a user wants to get a video's info before downloading.
-for (let funcName of ["getBasicInfo", "getInfo"]) {
+for (const funcName of ["getBasicInfo", "getInfo"]) {
   /**
    * @param {string} link
    * @param {Object} options
@@ -645,7 +661,7 @@ for (let funcName of ["getBasicInfo", "getInfo"]) {
   const func = exports[funcName];
   exports[funcName] = async (link, options = {}) => {
     utils.checkForUpdates();
-    let id = await urlUtils.getVideoID(link);
+    const id = await urlUtils.getVideoID(link);
     const key = [funcName, id, options.lang].join("-");
     return exports.cache.getOrSet(key, () => func(id, options));
   };

--- a/lib/info.js
+++ b/lib/info.js
@@ -422,7 +422,6 @@ const playerAPI = async (videoId, payload, options) => {
         "Content-Type": "application/json",
         Cookie: jar.getCookieStringSync("https://www.youtube.com"),
         "X-Goog-Api-Format-Version": "2",
-        "X-Goog-Visitor-Id": options.visitorId,
       },
       body: JSON.stringify(payload),
     },


### PR DESCRIPTION
The visitor data has been removed in commit 66f82a0.
However, I have found that the 'X-Goog-Visitor-Id' header is required for downloading some videos, such as [Rick Astley—Never Gonna Give You Up (Official Music Video)](https://www.youtube.com/watch?v=dQw4w9WgXcQ).