### PR TITLE
Match lockfile with package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "download",
     "distube"
   ],
-  "version": "4.16.8",
+  "version": "4.16.9",
   "repository": {
     "type": "git",
     "url": "git://github.com/distubejs/ytdl-core.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       http-cookie-agent:
-        specifier: ^6.0.8
+        specifier: ^7.0.1
         version: 6.0.8(tough-cookie@5.1.0)(undici@7.3.0)
       https-proxy-agent:
         specifier: ^7.0.6
@@ -27,7 +27,7 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       undici:
-        specifier: ^7.3.0
+        specifier: ^7.8.0
         version: 7.3.0
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Should fix the build failing during dependency install.