### PR TITLE
Fix proxy: use correct options object in createProxyAgent (#260)

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -90,7 +90,7 @@ exports.createProxyAgent = (options, cookies = []) => {
   const agent = new HttpsProxyAgent(options.uri);
 
   // ProxyAgent type that undici supports
-  const dispatcher = new ProxyAgent(proxyOptions).compose(cookie({ jar }));
+  const dispatcher = new ProxyAgent(options).compose(cookie({ jar }));
 
   return { dispatcher, agent, jar, localAddress: options.localAddress };
 };

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -2,105 +2,112 @@ const querystring = require("querystring");
 const Cache = require("./cache");
 const utils = require("./utils");
 const vm = require("vm");
+const { URL } = require("url");  // Import URL for parsing addresses
 
 exports.cache = new Cache(1);
 
+const DEFAULT_YT_HEADERS = {
+  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+  "Accept-Language": "en-US,en;q=0.9",
+  "Accept": "*/*",
+  "Referer": "https://www.youtube.com/",
+  "Origin": "https://www.youtube.com",
+  "sec-ch-ua": "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"126\"",
+  "sec-ch-ua-mobile": "?0",
+  "sec-ch-ua-platform": "\"Windows\"",
+  "sec-fetch-dest": "audio",
+  "sec-fetch-mode": "no-cors",
+  "sec-fetch-site": "cross-site"
+};
+
 exports.getFunctions = (html5playerfile, options) =>
   exports.cache.getOrSet(html5playerfile, async () => {
-    const body = await utils.request(html5playerfile, options);
+    const mergedOptions = Object.assign({}, options, {
+      headers: Object.assign({}, DEFAULT_YT_HEADERS, options?.headers),
+    });
+
+    const body = await utils.request(html5playerfile, mergedOptions);
     const functions = exports.extractFunctions(body);
     exports.cache.set(html5playerfile, functions);
     return functions;
   });
 
 const VARIABLE_PART = "[a-zA-Z_\\$][a-zA-Z_0-9\\$]*";
-const VARIABLE_PART_DEFINE = "\\\"?" + VARIABLE_PART + "\\\"?";
-const BEFORE_ACCESS = "(?:\\[\\\"|\\.)";
-const AFTER_ACCESS = "(?:\\\"\\]|)";
+const VARIABLE_PART_DEFINE = "\"?(" + VARIABLE_PART + ")\"?";
+const BEFORE_ACCESS = "(?:\\[\"|\\.)";
+const AFTER_ACCESS = "(?:\"\\]|)";
 const VARIABLE_PART_ACCESS = BEFORE_ACCESS + VARIABLE_PART + AFTER_ACCESS;
 const REVERSE_PART = ":function\\(\\w\\)\\{(?:return )?\\w\\.reverse\\(\\)\\}";
 const SLICE_PART = ":function\\(\\w,\\w\\)\\{return \\w\\.slice\\(\\w\\)\\}";
 const SPLICE_PART = ":function\\(\\w,\\w\\)\\{\\w\\.splice\\(0,\\w\\)\\}";
-const SWAP_PART = ":function\\(\\w,\\w\\)\\{" +
-    "var \\w=\\w\\[0\\];\\w\\[0\\]=\\w\\[\\w%\\w\\.length\\];\\w\\[\\w(?:%\\w.length|)\\]=\\w(?:;return \\w)?\\}";
+const SWAP_PART = ":function\\(a,b\\)\\{var c=a\\[0\\];a\\[0\\]=a\\[b%a\\.length\\];a\\[b(?:%a\\.length|)\\]=c(?:;return a)?\\}";
+const DECIPHER_REGEXP = "function(?: [a-zA-Z_$]+)?\\(a\\)\\{a=a\\.split\\(\"\"\\);\\s*((?:a=)?[a-zA-Z_$]+\\.[a-zA-Z_$]+\\(a,\\d+\\);)+return a\\.join\\(\"\"\\)\\}";
 
-const DECIPHER_REGEXP = 
-    "function(?: " + VARIABLE_PART + ")?\\(([a-zA-Z])\\)\\{" +
-    "\\1=\\1\\.split\\(\"\"\\);\\s*" +
-    "((?:(?:\\1=)?" + VARIABLE_PART + VARIABLE_PART_ACCESS + "\\(\\1,\\d+\\);)+)" +
-    "return \\1\\.join\\(\"\"\\)" +
-    "\\}";
+const HELPER_REGEXP = "var (" + VARIABLE_PART + ")=\\{((?:(?:" +
+  VARIABLE_PART_DEFINE + REVERSE_PART + "|" +
+  VARIABLE_PART_DEFINE + SLICE_PART + "|" +
+  VARIABLE_PART_DEFINE + SPLICE_PART + "|" +
+  VARIABLE_PART_DEFINE + SWAP_PART +
+  "),?\\n?)+)\\};";
 
-const HELPER_REGEXP = 
-    "var (" + VARIABLE_PART + ")=\\{((?:(?:" +
-    VARIABLE_PART_DEFINE + REVERSE_PART + "|" +
-    VARIABLE_PART_DEFINE + SLICE_PART + "|" +
-    VARIABLE_PART_DEFINE + SPLICE_PART + "|" +
-    VARIABLE_PART_DEFINE + SWAP_PART +
-    "),?\\n?)+)\\};";
+const FUNCTION_TCE_REGEXP = "function(?:\\s+[a-zA-Z_\\$][a-zA-Z0-9_\\$]*)?\\(\\w\\)\\{" +
+  "\\w=\\w\\.split\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+\\])\\);" +
+  "\\s*((?:(?:\\w=)?[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\[\\\"|\\.)[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\\"\\]|)\\(\\w,\\d+\\);)+)" +
+  "return \\w\\.join\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+\\])\\)}";
 
-const FUNCTION_TCE_REGEXP = 
-    "function(?:\\s+[a-zA-Z_\\$][a-zA-Z0-9_\\$]*)?\\(\\w\\)\\{" +
-    "\\w=\\w\\.split\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+])\\);" +
-    "\\s*((?:(?:\\w=)?[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\[\\\"|\\.)[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\\"\\]|)\\(\\w,\\d+\\);)+)" +
-    "return \\w\\.join\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+])\\)}";
+const N_TRANSFORM_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{(?:[^{}]*|\\{[^{}]*\\})*" +
+  "try\\s*\\{(?:[^{}]*|\\{[^{}]*\\})*\\}\\s*catch\\s*\\((\\w+)\\)\\s*\\{" +
+  "(?:[^{}]*|\\{[^{}]*\\})*return[^;]*;\\s*\\}" +
+  "(?:[^{}]*|\\{[^{}]*\\})*return[^;]*;\\s*\\}";
 
-const N_TRANSFORM_REGEXP = 
-    "function\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-    "var\\s*(\\w+)=(?:\\1\\.split\\(.*?\\)|String\\.prototype\\.split\\.call\\(\\1,.*?\\))," +
-    "\\s*(\\w+)=(\\[.*?]);\\s*\\3\\[\\d+]" +
-    "(.*?try)(\\{.*?})catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-    '\\s*return"[\\w-]+([A-z0-9-]+)"\\s*\\+\\s*\\1\\s*}' +
-    '\\s*return\\s*(\\2\\.join\\(""\\)|Array\\.prototype\\.join\\.call\\(\\2,.*?\\))};';
+const N_TRANSFORM_TCE_REGEXP =
+  "function\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
+  "\\s*(var|const)\\s*(\\w+)=\\1\\.split\\(\\s*['\"]{2}\\s*\\)," +
+  "\\s*(\\w+)=\\[.*?\\];.*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
+  "\\s*return[^}]+\\}" +
+  "\\s*return\\s*\\3\\.join\\(\\s*['\"]{2}\\s*\\)\\s*\\};";
 
-const N_TRANSFORM_TCE_REGEXP = 
-    "function\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-    "\\s*var\\s*(\\w+)=\\1\\.split\\(\\1\\.slice\\(0,0\\)\\),\\s*(\\w+)=\\[.*?];" +
-    ".*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-    "\\s*return(?:\"[^\"]+\"|\\s*[a-zA-Z_0-9$]*\\[\\d+])\\s*\\+\\s*\\1\\s*}" +
-    "\\s*return\\s*\\2\\.join\\((?:\"\"|[a-zA-Z_0-9$]*\\[\\d+])\\)};";
-  
-const TCE_GLOBAL_VARS_REGEXP = 
-    "(?:^|[;,])\\s*(var\\s+([\\w$]+)\\s*=\\s*" +
-    "(?:" +
-    "([\"'])(?:\\\\.|[^\\\\])*?\\3" +  
-    "\\s*\\.\\s*split\\((" +
-    "([\"'])(?:\\\\.|[^\\\\])*?\\5" +  
-    "\\))" +
-    "|" +  
-    "\\[\\s*(?:([\"'])(?:\\\\.|[^\\\\])*?\\6\\s*,?\\s*)+\\]" +
-    "))(?=\\s*[,;])";
-  
-const NEW_TCE_GLOBAL_VARS_REGEXP = 
-    "('use\\s*strict';)?" +
-    "(?<code>var\\s*" +
-    "(?<varname>[a-zA-Z0-9_$]+)\\s*=\\s*" +
-    "(?<value>" +
-    "(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
-    "\\.split\\(" +
-    "(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
-    "\\)" +
-    "|" +
-    "\\[" +
-    "(?:(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
-    "\\s*,?\\s*)*" +
-    "\\]" +
-    "|" +
-    "\"[^\"]*\"\\.split\\(\"[^\"]*\"\\)" +
-    ")" +
-    ")";
+const TCE_GLOBAL_VARS_REGEXP =
+  "(?:^|[;,])\\s*(var\\s+([\\w$]+)\\s*=\\s*" +
+  "(?:" +
+  "([\"'])(?:\\\\.|[^\\\\])*?\\3" +
+  "\\s*\\.\\s*split\\((" +
+  "([\"'])(?:\\\\.|[^\\\\])*?\\5" +
+  "\\))" +
+  "|" +
+  "\\[\\s*(?:([\"'])(?:\\\\.|[^\\\\])*?\\6\\s*,?\\s*)+\\]" +
+  "))(?=\\s*[,;])";
+
+const NEW_TCE_GLOBAL_VARS_REGEXP =
+  "('use\\s*strict';)?" +
+  "(?<code>var\\s*" +
+  "(?<varname>[a-zA-Z0-9_$]+)\\s*=\\s*" +
+  "(?<value>" +
+  "(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
+  "\\.split\\(" +
+  "(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
+  "\\)" +
+  "|" +
+  "\\[" +
+  "(?:(?:\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*')" +
+  "\\s*,?\\s*)*" +
+  "\\]" +
+  "|" +
+  "\"[^\"]*\"\\.split\\(\"[^\"]*\"\\)" +
+  ")" +
+  ")";
 
 const TCE_SIGN_FUNCTION_REGEXP = "function\\(\\s*([a-zA-Z0-9$])\\s*\\)\\s*\\{" +
-    "\\s*\\1\\s*=\\s*\\1\\[(\\w+)\\[\\d+\\]\\]\\(\\2\\[\\d+\\]\\);" +
-    "([a-zA-Z0-9$]+)\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
-    "\\s*\\3\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
-    ".*?return\\s*\\1\\[\\2\\[\\d+\\]\\]\\(\\2\\[\\d+\\]\\)\\};";
+  "\\s*\\1\\s*=\\s*\\1\\[(\\w+)\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\);" +
+  "([a-zA-Z0-9$]+)\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
+  "\\s*\\3\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
+  ".*?return\\s*\\1\\[\\2\\[\\d+\\]\\]\\(\\2\\[\\d+\\]\\)\\};";
 
-const TCE_SIGN_FUNCTION_ACTION_REGEXP = "var\\s*[a-zA-Z0-9$_]+\\s*=\\s*\\{\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\w+|\\s*\\w+\\s*,\\s*\\w+\\s*)\\)\\s*\\{\\s*(\\s*var\\s*\\w+=\\w+\\[\\d+\\];\\w+\\[\\d+\\]\\s*=\\s*\\w+\\[\\w+\\s*\\%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\];\\s*\\w+\\[\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+\\s*\\},|\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)\\},)\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\s*\\w+\\w*,\\s*\\w+\\s*|\\w+)\\)\\s*\\{(\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)|\\s*var\\s*\\w+\\s*=\\s*\\w+\\[\\d+\\]\\s*;\\w+\\[\\d+\\]\\s*=\\w+\\[\\s*\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*;\\w+\\[\\s*\\w+\\s*%\\s*\\w\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+\\s*)\\},\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\{\\w+\\[\\w+\\[\\d+\\]\\]\\(\\s*\\d+\\s*,\\s*\\w+\\s*\\)\\}\\};";
+const TCE_SIGN_FUNCTION_ACTION_REGEXP = "var\\s*[a-zA-Z0-9$_]+\\s*=\\s*\\{\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\w+|\\s*\\w+\\s*,\\s*\\w+\\s*)\\)\\s*\\{\\s*(\\s*var\\s*\\w+=\\w+\\[\\d+\\];\\w+\\[\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\];\\s*\\w+\\[\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+;\\s*)\\},|\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)\\},)\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\s*\\w+\\w*,\\s*\\w+\\s*|\\w+)\\)\\s*\\{(\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)|\\s*var\\s*\\w+\\s*=\\w+\\[\\d+\\];\\w+\\[\\d+\\]\\s*=\\w+\\[\\s*\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\;\\w+\\[\\s*\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+;\\s*)\\},\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\{\\w+\\[\\w+\\[\\d+\\]\\]\\(\\s*\\d+\\s*,\\s*\\w+\\s*\\)\\}\\};";
 
-const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\(\\s*(\\w+)\\s*\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\](\\+\\1)?\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\;";
+const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\](\\+\\1)?\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\;";
 
-const PATTERN_PREFIX = "(?:^|,)\\\"?(" + VARIABLE_PART + ")\\\"?";
+const PATTERN_PREFIX = "(?:^|,)\"?(" + VARIABLE_PART + ")\"?";
 const REVERSE_PATTERN = new RegExp(PATTERN_PREFIX + REVERSE_PART, "m");
 const SLICE_PATTERN = new RegExp(PATTERN_PREFIX + SLICE_PART, "m");
 const SPLICE_PATTERN = new RegExp(PATTERN_PREFIX + SPLICE_PART, "m");
@@ -113,38 +120,35 @@ const N_TRANSFORM_FUNC_NAME = "DisTubeNTransformFunc";
 
 const extractDollarEscapedFirstGroup = (pattern, text) => {
   const match = text.match(pattern);
-  return match ? match[1].replace(/\$/g, "\\$") : null;
+  return match ? match[1].replace(/\\$/g, "\\$") : null;
 };
 
 const extractTceFunc = (body) => {
   try {
     const tceVariableMatcher = body.match(new RegExp(NEW_TCE_GLOBAL_VARS_REGEXP, 'm'));
-
-    if (!tceVariableMatcher) return;
-
-    const tceVariableMatcherGroups = tceVariableMatcher.groups;
-    if (!tceVariableMatcher.groups) return;
-
-    const code = tceVariableMatcherGroups.code;
-    const varname = tceVariableMatcherGroups.varname;
-
-    return { name: varname, code: code };
+    if (!tceVariableMatcher?.groups) {
+      console.error("Failed in extractTceFunc - player script might be updated?");
+      utils.saveDebugFile("player-error.js", body);
+      return null;
+    }
+    const { code, varname } = tceVariableMatcher.groups;
+    return { name: varname, code };
   } catch (e) {
     console.error("Error in extractTceFunc:", e);
     return null;
   }
-}
+};
 
 const extractDecipherFunc = (body, name, code) => {
   try {
-    const callerFunc = DECIPHER_FUNC_NAME + "(" + DECIPHER_ARGUMENT + ");";
+    const callerFunc = `${DECIPHER_FUNC_NAME}(${DECIPHER_ARGUMENT});`;
     let resultFunc;
 
     const sigFunctionMatcher = body.match(new RegExp(TCE_SIGN_FUNCTION_REGEXP, 's'));
     const sigFunctionActionsMatcher = body.match(new RegExp(TCE_SIGN_FUNCTION_ACTION_REGEXP, 's'));
 
     if (sigFunctionMatcher && sigFunctionActionsMatcher && code) {
-      resultFunc = "var " + DECIPHER_FUNC_NAME + "=" + sigFunctionMatcher[0] + sigFunctionActionsMatcher[0] + code + ";\n";
+      resultFunc = `var ${DECIPHER_FUNC_NAME}=${sigFunctionMatcher[0]}${sigFunctionActionsMatcher[0]}${code};\n`;
       return resultFunc + callerFunc;
     }
 
@@ -162,7 +166,7 @@ const extractDecipherFunc = (body, name, code) => {
 
     const quotedFunctions = [reverseKey, sliceKey, spliceKey, swapKey]
       .filter(Boolean)
-      .map(key => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')); 
+      .map(key => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
 
     if (quotedFunctions.length === 0) return null;
 
@@ -173,10 +177,8 @@ const extractDecipherFunc = (body, name, code) => {
     if (funcMatch) {
       decipherFunc = funcMatch[0];
     } else {
-
       const tceFuncMatch = body.match(new RegExp(FUNCTION_TCE_REGEXP, "s"));
       if (!tceFuncMatch) return null;
-
       decipherFunc = tceFuncMatch[0];
       isTce = true;
     }
@@ -184,12 +186,10 @@ const extractDecipherFunc = (body, name, code) => {
     let tceVars = "";
     if (isTce) {
       const tceVarsMatch = body.match(new RegExp(TCE_GLOBAL_VARS_REGEXP, "m"));
-      if (tceVarsMatch) {
-        tceVars = tceVarsMatch[1] + ";\n";
-      }
+      if (tceVarsMatch) tceVars = tceVarsMatch[1] + ";\n";
     }
 
-    resultFunc = tceVars + helperObject + "\nvar " + DECIPHER_FUNC_NAME + "=" + decipherFunc + ";\n";
+    resultFunc = tceVars + helperObject + `\nvar ${DECIPHER_FUNC_NAME}=${decipherFunc};\n`;
     return resultFunc + callerFunc;
   } catch (e) {
     console.error("Error in extractDecipherFunc:", e);
@@ -199,63 +199,51 @@ const extractDecipherFunc = (body, name, code) => {
 
 const extractNTransformFunc = (body, name, code) => {
   try {
-    const callerFunc = N_TRANSFORM_FUNC_NAME + "(" + N_ARGUMENT + ");";
+    const callerFunc = `${N_TRANSFORM_FUNC_NAME}(${N_ARGUMENT});`;
     let resultFunc;
     let nFunction;
 
     const nFunctionMatcher = body.match(new RegExp(TCE_N_FUNCTION_REGEXP, 's'));
-
     if (nFunctionMatcher && name && code) {
       nFunction = nFunctionMatcher[0];
-  
-      const tceEscapeName = name.replace("$", "\\$");
+      const tceEscapeName = name.replace("$", "\\\\$");
       const shortCircuitPattern = new RegExp(
-        `;\\s*if\\s*\\(\\s*typeof\\s+[a-zA-Z0-9_$]+\\s*===?\\s*(?:\"undefined\"|'undefined'|${tceEscapeName}\\[\\d+\\])\\s*\\)\\s*return\\s+\\w+;`
+        `;\\s*if\\s*\\(\\s*typeof\\s+[a-zA-Z0-9_$]+\\s*===?\\s*(?:"undefined"|'undefined'|${tceEscapeName}\\[\\d+\\])\\s*\\)\\s*return\\s+\\w+;`
       );
-
       const tceShortCircuitMatcher = nFunction.match(shortCircuitPattern);
-    
       if (tceShortCircuitMatcher) {
         nFunction = nFunction.replaceAll(tceShortCircuitMatcher[0], ";");
       }
-
-      resultFunc = "var " + N_TRANSFORM_FUNC_NAME + "=" + nFunction + code + ";\n";
+      resultFunc = `var ${N_TRANSFORM_FUNC_NAME}=${nFunction}${code};\n`;
       return resultFunc + callerFunc;
     }
 
     let nMatch = body.match(new RegExp(N_TRANSFORM_REGEXP, "s"));
     let isTce = false;
-
     if (nMatch) {
       nFunction = nMatch[0];
     } else {
-
       const nTceMatch = body.match(new RegExp(N_TRANSFORM_TCE_REGEXP, "s"));
       if (!nTceMatch) return null;
-
       nFunction = nTceMatch[0];
       isTce = true;
     }
 
-    const paramMatch = nFunction.match(/function\s*\(\s*(\w+)\s*\)/);
+    const paramMatch = nFunction.match(/function\\s*\\(\\s*(\\w+)\\s*\\)/);
     if (!paramMatch) return null;
-
     const paramName = paramMatch[1];
-
     const cleanedFunction = nFunction.replace(
-      new RegExp(`if\\s*\\(typeof\\s*[^\\s()]+\\s*===?.*?\\)return ${paramName}\\s*;?`, "g"), 
+      new RegExp(`if\\s*\\(typeof\\s*[^\\s()]+\\s*===?.*?\\)return ${paramName}\\s*;?`, "g"),
       ""
     );
 
     let tceVars = "";
     if (isTce) {
       const tceVarsMatch = body.match(new RegExp(TCE_GLOBAL_VARS_REGEXP, "m"));
-      if (tceVarsMatch) {
-        tceVars = tceVarsMatch[1] + ";\n";
-      }
+      if (tceVarsMatch) tceVars = tceVarsMatch[1] + ";\n";
     }
 
-    resultFunc = tceVars + "var " + N_TRANSFORM_FUNC_NAME + "=" + cleanedFunction + ";\n";
+    resultFunc = tceVars + `var ${N_TRANSFORM_FUNC_NAME}=${cleanedFunction};\n`;
     return resultFunc + callerFunc;
   } catch (e) {
     console.error("Error in extractNTransformFunc:", e);
@@ -271,9 +259,9 @@ const getExtractFunction = (extractFunctions, body, name, code, postProcess = nu
     try {
       const func = extractFunction(body, name, code);
       if (!func) continue;
-      return new vm.Script(postProcess ? postProcess(func) : func);
+      return new vm.Script(postProcess?.(func) ?? func);
     } catch (err) {
-      console.error("Failed to extract function:", err);
+      console.error("Error extracting function:", err);
       continue;
     }
   }
@@ -284,12 +272,8 @@ const extractDecipher = (body, name, code) => {
   const decipherFunc = getExtractFunction([extractDecipherFunc], body, name, code);
   if (!decipherFunc && !decipherWarning) {
     console.warn(
-      "\x1b[33mWARNING:\x1B[0m Could not parse decipher function.\n" +
-        "Stream URLs will be missing.\n" +
-        `Please report this issue by uploading the "${utils.saveDebugFile(
-          "player-script.js",
-          body,
-        )}" file on https://github.com/distubejs/ytdl-core/issues/144.`
+      "\x1b[33mWARNING:\x1B[0m Could not parse the decipher function.\n" +
+      `Report this error by uploading the file: "${utils.saveDebugFile("player-script.js", body)}"`
     );
     decipherWarning = true;
   }
@@ -298,90 +282,123 @@ const extractDecipher = (body, name, code) => {
 
 const extractNTransform = (body, name, code) => {
   const nTransformFunc = getExtractFunction([extractNTransformFunc], body, name, code);
-
   if (!nTransformFunc && !nTransformWarning) {
     console.warn(
-      "\x1b[33mWARNING:\x1B[0m Could not parse n transform function.\n" +
-      `Please report this issue by uploading the "${utils.saveDebugFile(
-        "player-script.js",
-        body,
-      )}" file on https://github.com/distubejs/ytdl-core/issues/144.`
+      "\x1b[33mWARNING:\x1B[0m Could not parse the 'n' transformation function.\n" +
+      `Report this error by uploading the file: "${utils.saveDebugFile("player-script.js", body)}"`
     );
     nTransformWarning = true;
   }
-
   return nTransformFunc;
 };
 
 exports.extractFunctions = body => {
-  const { name, code } = extractTceFunc(body);
-  return [extractDecipher(body, name, code), extractNTransform(body, name, code)];
-}
+  const tceData = extractTceFunc(body);
+  if (!tceData) return [null, null];
+
+  try {
+    // Basic VM test
+    new vm.Script('function test(){}').runInNewContext();
+  } catch (e) {
+    console.error("Error testing functions:", e);
+  }
+
+  return [
+    extractDecipher(body, tceData.name, tceData.code),
+    extractNTransform(body, tceData.name, tceData.code)
+  ];
+};
 
 exports.setDownloadURL = (format, decipherScript, nTransformScript) => {
   if (!format) return;
 
-  const decipher = url => {
-    const args = querystring.parse(url);
-    if (!args.s || !decipherScript) return args.url;
+  let originalUrl;
+  let hasCipher = false;
 
-    try {
-      const components = new URL(decodeURIComponent(args.url));
-      const context = {};
-      context[DECIPHER_ARGUMENT] = decodeURIComponent(args.s);
-      const decipheredSig = decipherScript.runInNewContext(context);
-
-      components.searchParams.set(args.sp || "sig", decipheredSig);
-      return components.toString();
-    } catch (err) {
-      console.error("Error applying decipher:", err);
-      return args.url;
-    }
-  };
-
-  const nTransform = url => {
-    try {
-      const components = new URL(decodeURIComponent(url));
-      const n = components.searchParams.get("n");
-
-      if (!n || !nTransformScript) return url;
-
-      const context = {};
-      context[N_ARGUMENT] = n;
-      const transformedN = nTransformScript.runInNewContext(context);
-
-      if (transformedN) {
-
-        if (n === transformedN) {
-          console.warn("Transformed n parameter is the same as input, n function possibly short-circuited");
-        } else if (transformedN.startsWith("enhanced_except_") || transformedN.endsWith("_w8_" + n)) {
-          console.warn("N function did not complete due to exception");
-        }
-
-        components.searchParams.set("n", transformedN);
-      } else {
-        console.warn("Transformed n parameter is null, n function possibly faulty");
-      }
-
-      return components.toString();
-    } catch (err) {
-      console.error("Error applying n transform:", err);
-      return url;
-    }
-  };
-
-  const cipher = !format.url;
-  const url = format.url || format.signatureCipher || format.cipher;
-
-  if (!url) return;
+  if (format.url) {
+    originalUrl = format.url;
+  } else if (format.signatureCipher || format.cipher) {
+    hasCipher = true;
+    originalUrl = format.signatureCipher || format.cipher;
+  } else {
+    return;
+  }
 
   try {
-    format.url = nTransform(cipher ? decipher(url) : url);
+    let finalUrl;
 
+    if (hasCipher) {
+      const args = querystring.parse(originalUrl);
+      if (!args.url) return;
+
+      finalUrl = decodeURIComponent(args.url);
+      const urlObj = new URL(finalUrl);
+
+      // --- Signature (sig) ---
+      const sigParamName = args.sp || "sig";
+      if (args.s) {
+        let sigValue = decodeURIComponent(args.s);
+        if (decipherScript) {
+          try {
+            const context = { [DECIPHER_ARGUMENT]: sigValue };
+            const out = decipherScript.runInNewContext(context);
+            if (out) sigValue = out;
+          } catch (e) {
+            console.error("Error deciphering signature:", e);
+          }
+        }
+        urlObj.searchParams.set(sigParamName, sigValue);
+      } else if (args.sig) {
+        urlObj.searchParams.set(sigParamName, args.sig);
+      }
+
+      // --- n Parameter ---
+      if (nTransformScript) {
+        const nParam = urlObj.searchParams.get("n");
+        if (nParam) {
+          try {
+            const context = { [N_ARGUMENT]: nParam };
+            const transformedN = nTransformScript.runInNewContext(context);
+            if (transformedN && transformedN !== nParam) {
+              urlObj.searchParams.set("n", transformedN);
+              console.log(`Transformed n parameter: ${nParam} -> ${transformedN}`);
+            }
+          } catch (e) {
+            console.error("Error transforming n:", e);
+          }
+        }
+      }
+
+      finalUrl = urlObj.toString();
+    } else {
+      // Unencrypted URLs: only n parameter
+      finalUrl = originalUrl;
+      if (nTransformScript) {
+        try {
+          const urlObj = new URL(finalUrl);
+          const nParam = urlObj.searchParams.get("n");
+          if (nParam) {
+            const context = { [N_ARGUMENT]: nParam };
+            const transformedN = nTransformScript.runInNewContext(context);
+            if (transformedN && transformedN !== nParam) {
+              urlObj.searchParams.set("n", transformedN);
+              finalUrl = urlObj.toString();
+              console.log(`Transformed n parameter: ${nParam} -> ${transformedN}`);
+            }
+          }
+        } catch (e) {
+          console.error("Error transforming n on unencrypted URL:", e);
+        }
+      }
+    }
+
+    // Update and clean
+    format.url = finalUrl;
     delete format.signatureCipher;
     delete format.cipher;
+    console.log(`Processed URL: ${finalUrl.substring(0, 100)}...`);
   } catch (err) {
-    console.error("Error setting download URL:", err);
+    console.error("Error processing URL:", err);
   }
 };
 

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -98,7 +98,7 @@ const TCE_SIGN_FUNCTION_REGEXP = "function\\(\\s*([a-zA-Z0-9$])\\s*\\)\\s*\\{" +
 
 const TCE_SIGN_FUNCTION_ACTION_REGEXP = "var\\s+([A-Za-z0-9_]+)\\s*=\\s*\\{\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*,\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*,\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*\\};";
 
-const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\(\\s*(\\w+)\\s*\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\](\\+\\1)?\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\;";
+const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\s*\\(\\s*(\\w+)\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\]\\s*\\+\\s*\\1\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\s*\\;";
 
 const PATTERN_PREFIX = "(?:^|,)\\\"?(" + VARIABLE_PART + ")\\\"?";
 const REVERSE_PATTERN = new RegExp(PATTERN_PREFIX + REVERSE_PART, "m");
@@ -199,7 +199,6 @@ const extractDecipherFunc = (body, name, code) => {
 
 const extractNTransformFunc = (body, name, code) => {
   try {
-
     const callerFunc = N_TRANSFORM_FUNC_NAME + "(" + N_ARGUMENT + ");";
     let resultFunc;
     let nFunction;
@@ -210,7 +209,6 @@ const extractNTransformFunc = (body, name, code) => {
       nFunction = nFunctionMatcher[0];
 
       const tceEscapeName = name.replace("$", "\\$");
-
       const shortCircuitPattern = new RegExp(
         `;\\s*if\\s*\\(\\s*typeof\\s+[a-zA-Z0-9_$]+\\s*===?\\s*(?:\"undefined\"|'undefined'|${tceEscapeName}\\[\\d+\\])\\s*\\)\\s*return\\s+\\w+;`
       );
@@ -387,19 +385,21 @@ exports.setDownloadURL = (format, decipherScript, nTransformScript) => {
   }
 };
 
-/**
- * Applies decipher and n parameter transforms to all format URL's.
- *
- * @param {Array.<Object>} formats
- * @param {string} html5player
- * @param {Object} options
- */
 exports.decipherFormats = async (formats, html5player, options) => {
-  const decipheredFormats = {};
-  const [decipherScript, nTransformScript] = await exports.getFunctions(html5player, options);
-  formats.forEach(format => {
-    exports.setDownloadURL(format, decipherScript, nTransformScript);
-    decipheredFormats[format.url] = format;
-  });
-  return decipheredFormats;
+  try {
+    const decipheredFormats = {};
+    const [decipherScript, nTransformScript] = await exports.getFunctions(html5player, options);
+
+    formats.forEach(format => {
+      exports.setDownloadURL(format, decipherScript, nTransformScript);
+      if (format.url) {
+        decipheredFormats[format.url] = format;
+      }
+    });
+
+    return decipheredFormats;
+  } catch (err) {
+    console.error("Error deciphering formats:", err);
+    return {};
+  }
 };

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -2,70 +2,63 @@ const querystring = require("querystring");
 const Cache = require("./cache");
 const utils = require("./utils");
 const vm = require("vm");
-const { URL } = require("url");  // Import URL for parsing addresses
 
 exports.cache = new Cache(1);
 
-const DEFAULT_YT_HEADERS = {
-  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-  "Accept-Language": "en-US,en;q=0.9",
-  "Accept": "*/*",
-  "Referer": "https://www.youtube.com/",
-  "Origin": "https://www.youtube.com",
-  "sec-ch-ua": "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"126\"",
-  "sec-ch-ua-mobile": "?0",
-  "sec-ch-ua-platform": "\"Windows\"",
-  "sec-fetch-dest": "audio",
-  "sec-fetch-mode": "no-cors",
-  "sec-fetch-site": "cross-site"
-};
-
 exports.getFunctions = (html5playerfile, options) =>
   exports.cache.getOrSet(html5playerfile, async () => {
-    const mergedOptions = Object.assign({}, options, {
-      headers: Object.assign({}, DEFAULT_YT_HEADERS, options?.headers),
-    });
-
-    const body = await utils.request(html5playerfile, mergedOptions);
+    const body = await utils.request(html5playerfile, options);
     const functions = exports.extractFunctions(body);
     exports.cache.set(html5playerfile, functions);
     return functions;
   });
 
 const VARIABLE_PART = "[a-zA-Z_\\$][a-zA-Z_0-9\\$]*";
-const VARIABLE_PART_DEFINE = "\"?(" + VARIABLE_PART + ")\"?";
-const BEFORE_ACCESS = "(?:\\[\"|\\.)";
-const AFTER_ACCESS = "(?:\"\\]|)";
+const VARIABLE_PART_DEFINE = "\\\"?" + VARIABLE_PART + "\\\"?";
+const BEFORE_ACCESS = "(?:\\[\\\"|\\.)";
+const AFTER_ACCESS = "(?:\\\"\\]|)";
 const VARIABLE_PART_ACCESS = BEFORE_ACCESS + VARIABLE_PART + AFTER_ACCESS;
 const REVERSE_PART = ":function\\(\\w\\)\\{(?:return )?\\w\\.reverse\\(\\)\\}";
 const SLICE_PART = ":function\\(\\w,\\w\\)\\{return \\w\\.slice\\(\\w\\)\\}";
 const SPLICE_PART = ":function\\(\\w,\\w\\)\\{\\w\\.splice\\(0,\\w\\)\\}";
-const SWAP_PART = ":function\\(a,b\\)\\{var c=a\\[0\\];a\\[0\\]=a\\[b%a\\.length\\];a\\[b(?:%a\\.length|)\\]=c(?:;return a)?\\}";
-const DECIPHER_REGEXP = "function(?: [a-zA-Z_$]+)?\\(a\\)\\{a=a\\.split\\(\"\"\\);\\s*((?:a=)?[a-zA-Z_$]+\\.[a-zA-Z_$]+\\(a,\\d+\\);)+return a\\.join\\(\"\"\\)\\}";
+const SWAP_PART = ":function\\(\\w,\\w\\)\\{" +
+  "var \\w=\\w\\[0\\];\\w\\[0\\]=\\w\\[\\w%\\w\\.length\\];\\w\\[\\w(?:%\\w.length|)\\]=\\w(?:;return \\w)?\\}";
 
-const HELPER_REGEXP = "var (" + VARIABLE_PART + ")=\\{((?:(?:" +
+const DECIPHER_REGEXP =
+  "function(?: " + VARIABLE_PART + ")?\\(([a-zA-Z])\\)\\{" +
+  "\\1=\\1\\.split\\(\"\"\\);\\s*" +
+  "((?:(?:\\1=)?" + VARIABLE_PART + VARIABLE_PART_ACCESS + "\\(\\1,\\d+\\);)+)" +
+  "return \\1\\.join\\(\"\"\\)" +
+  "\\}";
+
+const HELPER_REGEXP =
+  "var (" + VARIABLE_PART + ")=\\{((?:(?:" +
   VARIABLE_PART_DEFINE + REVERSE_PART + "|" +
   VARIABLE_PART_DEFINE + SLICE_PART + "|" +
   VARIABLE_PART_DEFINE + SPLICE_PART + "|" +
   VARIABLE_PART_DEFINE + SWAP_PART +
   "),?\\n?)+)\\};";
 
-const FUNCTION_TCE_REGEXP = "function(?:\\s+[a-zA-Z_\\$][a-zA-Z0-9_\\$]*)?\\(\\w\\)\\{" +
-  "\\w=\\w\\.split\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+\\])\\);" +
+const FUNCTION_TCE_REGEXP =
+  "function(?:\\s+[a-zA-Z_\\$][a-zA-Z0-9_\\$]*)?\\(\\w\\)\\{" +
+  "\\w=\\w\\.split\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+])\\);" +
   "\\s*((?:(?:\\w=)?[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\[\\\"|\\.)[a-zA-Z_\\$][a-zA-Z0-9_\\$]*(?:\\\"\\]|)\\(\\w,\\d+\\);)+)" +
-  "return \\w\\.join\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+\\])\\)}";
+  "return \\w\\.join\\((?:\"\"|[a-zA-Z0-9_$]*\\[\\d+])\\)}";
 
-const N_TRANSFORM_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{(?:[^{}]*|\\{[^{}]*\\})*" +
-  "try\\s*\\{(?:[^{}]*|\\{[^{}]*\\})*\\}\\s*catch\\s*\\((\\w+)\\)\\s*\\{" +
-  "(?:[^{}]*|\\{[^{}]*\\})*return[^;]*;\\s*\\}" +
-  "(?:[^{}]*|\\{[^{}]*\\})*return[^;]*;\\s*\\}";
+const N_TRANSFORM_REGEXP =
+  "function\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
+  "var\\s*(\\w+)=(?:\\1\\.split\\(.*?\\)|String\\.prototype\\.split\\.call\\(\\1,.*?\\))," +
+  "\\s*(\\w+)=(\\[.*?]);\\s*\\3\\[\\d+]" +
+  "(.*?try)(\\{.*?})catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
+  '\\s*return"[\\w-]+([A-z0-9-]+)"\\s*\\+\\s*\\1\\s*}' +
+  '\\s*return\\s*(\\2\\.join\\(""\\)|Array\\.prototype\\.join\\.call\\(\\2,.*?\\))};';
 
 const N_TRANSFORM_TCE_REGEXP =
   "function\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-  "\\s*(var|const)\\s*(\\w+)=\\1\\.split\\(\\s*['\"]{2}\\s*\\)," +
-  "\\s*(\\w+)=\\[.*?\\];.*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
-  "\\s*return[^}]+\\}" +
-  "\\s*return\\s*\\3\\.join\\(\\s*['\"]{2}\\s*\\)\\s*\\};";
+  "\\s*var\\s*(\\w+)=\\1\\.split\\(\\1\\.slice\\(0,0\\)\\),\\s*(\\w+)=\\[.*?];" +
+  ".*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{" +
+  "\\s*return(?:\"[^\"]+\"|\\s*[a-zA-Z_0-9$]*\\[\\d+])\\s*\\+\\s*\\1\\s*}" +
+  "\\s*return\\s*\\2\\.join\\((?:\"\"|[a-zA-Z_0-9$]*\\[\\d+])\\)};";
 
 const TCE_GLOBAL_VARS_REGEXP =
   "(?:^|[;,])\\s*(var\\s+([\\w$]+)\\s*=\\s*" +
@@ -98,16 +91,16 @@ const NEW_TCE_GLOBAL_VARS_REGEXP =
   ")";
 
 const TCE_SIGN_FUNCTION_REGEXP = "function\\(\\s*([a-zA-Z0-9$])\\s*\\)\\s*\\{" +
-  "\\s*\\1\\s*=\\s*\\1\\[(\\w+)\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\);" +
+  "\\s*\\1\\s*=\\s*\\1\\[(\\w+)\\[\\d+\\]\\]\\(\\2\\[\\d+\\]\\);" +
   "([a-zA-Z0-9$]+)\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
   "\\s*\\3\\[\\2\\[\\d+\\]\\]\\(\\s*\\1\\s*,\\s*\\d+\\s*\\);" +
   ".*?return\\s*\\1\\[\\2\\[\\d+\\]\\]\\(\\2\\[\\d+\\]\\)\\};";
 
-const TCE_SIGN_FUNCTION_ACTION_REGEXP = "var\\s*[a-zA-Z0-9$_]+\\s*=\\s*\\{\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\w+|\\s*\\w+\\s*,\\s*\\w+\\s*)\\)\\s*\\{\\s*(\\s*var\\s*\\w+=\\w+\\[\\d+\\];\\w+\\[\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\];\\s*\\w+\\[\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+;\\s*)\\},|\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)\\},)\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\((\\s*\\w+\\w*,\\s*\\w+\\s*|\\w+)\\)\\s*\\{(\\w+\\[\\w+\\[\\d+\\]\\]\\(\\)|\\s*var\\s*\\w+\\s*=\\w+\\[\\d+\\];\\w+\\[\\d+\\]\\s*=\\w+\\[\\s*\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\;\\w+\\[\\s*\\w+\\s*%\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\]\\s*=\\s*\\w+;\\s*)\\},\\s*[a-zA-Z0-9$_]+\\s*:\\s*function\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\{\\w+\\[\\w+\\[\\d+\\]\\]\\(\\s*\\d+\\s*,\\s*\\w+\\s*\\)\\}\\};";
+const TCE_SIGN_FUNCTION_ACTION_REGEXP = "var\\s+([A-Za-z0-9_]+)\\s*=\\s*\\{\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*,\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*,\\s*(?:[A-Za-z0-9_]+)\\s*:\\s*function\\s*\\([^)]*\\)\\s*\\{[^{}]*(?:\\{[^{}]*\\}[^{}]*)*\\}\\s*\\};";
 
-const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\(\\s*(\\w+)\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\](\\+\\1)?\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\;";
+const TCE_N_FUNCTION_REGEXP = "function\\s*\\((\\w+)\\)\\s*\\{var\\s*\\w+\\s*=\\s*\\1\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\s*,\\s*\\w+\\s*=\\s*\\[.*?\\]\\;.*?catch\\(\\s*(\\w+)\\s*\\s*\\)\\s*\\{return\\s*\\w+\\[\\d+\\](\\+\\1)?\\}\\s*return\\s*\\w+\\[\\w+\\[\\d+\\]\\]\\(\\w+\\[\\d+\\]\\)\\}\\;";
 
-const PATTERN_PREFIX = "(?:^|,)\"?(" + VARIABLE_PART + ")\"?";
+const PATTERN_PREFIX = "(?:^|,)\\\"?(" + VARIABLE_PART + ")\\\"?";
 const REVERSE_PATTERN = new RegExp(PATTERN_PREFIX + REVERSE_PART, "m");
 const SLICE_PATTERN = new RegExp(PATTERN_PREFIX + SLICE_PART, "m");
 const SPLICE_PATTERN = new RegExp(PATTERN_PREFIX + SPLICE_PART, "m");
@@ -120,35 +113,38 @@ const N_TRANSFORM_FUNC_NAME = "DisTubeNTransformFunc";
 
 const extractDollarEscapedFirstGroup = (pattern, text) => {
   const match = text.match(pattern);
-  return match ? match[1].replace(/\\$/g, "\\$") : null;
+  return match ? match[1].replace(/\$/g, "\\$") : null;
 };
 
 const extractTceFunc = (body) => {
   try {
     const tceVariableMatcher = body.match(new RegExp(NEW_TCE_GLOBAL_VARS_REGEXP, 'm'));
-    if (!tceVariableMatcher?.groups) {
-      console.error("Failed in extractTceFunc - player script might be updated?");
-      utils.saveDebugFile("player-error.js", body);
-      return null;
-    }
-    const { code, varname } = tceVariableMatcher.groups;
-    return { name: varname, code };
+
+    if (!tceVariableMatcher) return;
+
+    const tceVariableMatcherGroups = tceVariableMatcher.groups;
+    if (!tceVariableMatcher.groups) return;
+
+    const code = tceVariableMatcherGroups.code;
+    const varname = tceVariableMatcherGroups.varname;
+
+    return { name: varname, code: code };
   } catch (e) {
     console.error("Error in extractTceFunc:", e);
     return null;
   }
-};
+}
 
 const extractDecipherFunc = (body, name, code) => {
   try {
-    const callerFunc = `${DECIPHER_FUNC_NAME}(${DECIPHER_ARGUMENT});`;
+    const callerFunc = DECIPHER_FUNC_NAME + "(" + DECIPHER_ARGUMENT + ");";
     let resultFunc;
 
     const sigFunctionMatcher = body.match(new RegExp(TCE_SIGN_FUNCTION_REGEXP, 's'));
     const sigFunctionActionsMatcher = body.match(new RegExp(TCE_SIGN_FUNCTION_ACTION_REGEXP, 's'));
 
     if (sigFunctionMatcher && sigFunctionActionsMatcher && code) {
-      resultFunc = `var ${DECIPHER_FUNC_NAME}=${sigFunctionMatcher[0]}${sigFunctionActionsMatcher[0]}${code};\n`;
+      resultFunc = "var " + DECIPHER_FUNC_NAME + "=" + sigFunctionMatcher[0] + sigFunctionActionsMatcher[0] + code + ";\n";
       return resultFunc + callerFunc;
     }
 
@@ -177,8 +173,10 @@ const extractDecipherFunc = (body, name, code) => {
     if (funcMatch) {
       decipherFunc = funcMatch[0];
     } else {
+
       const tceFuncMatch = body.match(new RegExp(FUNCTION_TCE_REGEXP, "s"));
       if (!tceFuncMatch) return null;
+
       decipherFunc = tceFuncMatch[0];
       isTce = true;
     }
@@ -186,10 +184,12 @@ const extractDecipherFunc = (body, name, code) => {
     let tceVars = "";
     if (isTce) {
       const tceVarsMatch = body.match(new RegExp(TCE_GLOBAL_VARS_REGEXP, "m"));
-      if (tceVarsMatch) tceVars = tceVarsMatch[1] + ";\n";
+      if (tceVarsMatch) {
+        tceVars = tceVarsMatch[1] + ";\n";
+      }
     }
 
-    resultFunc = tceVars + helperObject + `\nvar ${DECIPHER_FUNC_NAME}=${decipherFunc};\n`;
+    resultFunc = tceVars + helperObject + "\nvar " + DECIPHER_FUNC_NAME + "=" + decipherFunc + ";\n";
     return resultFunc + callerFunc;
   } catch (e) {
     console.error("Error in extractDecipherFunc:", e);
@@ -199,39 +199,51 @@ const extractDecipherFunc = (body, name, code) => {
 
 const extractNTransformFunc = (body, name, code) => {
   try {
-    const callerFunc = `${N_TRANSFORM_FUNC_NAME}(${N_ARGUMENT});`;
+
+    const callerFunc = N_TRANSFORM_FUNC_NAME + "(" + N_ARGUMENT + ");";
     let resultFunc;
     let nFunction;
 
     const nFunctionMatcher = body.match(new RegExp(TCE_N_FUNCTION_REGEXP, 's'));
+
     if (nFunctionMatcher && name && code) {
       nFunction = nFunctionMatcher[0];
-      const tceEscapeName = name.replace("$", "\\\\$");
+
+      const tceEscapeName = name.replace("$", "\\$");
+
       const shortCircuitPattern = new RegExp(
-        `;\\s*if\\s*\\(\\s*typeof\\s+[a-zA-Z0-9_$]+\\s*===?\\s*(?:"undefined"|'undefined'|${tceEscapeName}\\[\\d+\\])\\s*\\)\\s*return\\s+\\w+;`
+        `;\\s*if\\s*\\(\\s*typeof\\s+[a-zA-Z0-9_$]+\\s*===?\\s*(?:\"undefined\"|'undefined'|${tceEscapeName}\\[\\d+\\])\\s*\\)\\s*return\\s+\\w+;`
       );
+
       const tceShortCircuitMatcher = nFunction.match(shortCircuitPattern);
+
       if (tceShortCircuitMatcher) {
         nFunction = nFunction.replaceAll(tceShortCircuitMatcher[0], ";");
       }
-      resultFunc = `var ${N_TRANSFORM_FUNC_NAME}=${nFunction}${code};\n`;
+
+      resultFunc = "var " + N_TRANSFORM_FUNC_NAME + "=" + nFunction + code + ";\n";
       return resultFunc + callerFunc;
     }
 
     let nMatch = body.match(new RegExp(N_TRANSFORM_REGEXP, "s"));
     let isTce = false;
+
     if (nMatch) {
       nFunction = nMatch[0];
     } else {
+
       const nTceMatch = body.match(new RegExp(N_TRANSFORM_TCE_REGEXP, "s"));
       if (!nTceMatch) return null;
+
       nFunction = nTceMatch[0];
       isTce = true;
     }
 
-    const paramMatch = nFunction.match(/function\\s*\\(\\s*(\\w+)\\s*\\)/);
+    const paramMatch = nFunction.match(/function\s*\(\s*(\w+)\s*\)/);
     if (!paramMatch) return null;
+
     const paramName = paramMatch[1];
+
     const cleanedFunction = nFunction.replace(
       new RegExp(`if\\s*\\(typeof\\s*[^\\s()]+\\s*===?.*?\\)return ${paramName}\\s*;?`, "g"),
       ""
@@ -240,10 +252,12 @@ const extractNTransformFunc = (body, name, code) => {
     let tceVars = "";
     if (isTce) {
       const tceVarsMatch = body.match(new RegExp(TCE_GLOBAL_VARS_REGEXP, "m"));
-      if (tceVarsMatch) tceVars = tceVarsMatch[1] + ";\n";
+      if (tceVarsMatch) {
+        tceVars = tceVarsMatch[1] + ";\n";
+      }
     }
 
-    resultFunc = tceVars + `var ${N_TRANSFORM_FUNC_NAME}=${cleanedFunction};\n`;
+    resultFunc = tceVars + "var " + N_TRANSFORM_FUNC_NAME + "=" + cleanedFunction + ";\n";
     return resultFunc + callerFunc;
   } catch (e) {
     console.error("Error in extractNTransformFunc:", e);
@@ -259,9 +273,9 @@ const getExtractFunction = (extractFunctions, body, name, code, postProcess = nu
     try {
       const func = extractFunction(body, name, code);
       if (!func) continue;
-      return new vm.Script(postProcess?.(func) ?? func);
+      return new vm.Script(postProcess ? postProcess(func) : func);
     } catch (err) {
-      console.error("Error extracting function:", err);
+      console.error("Failed to extract function:", err);
       continue;
     }
   }
@@ -272,8 +286,12 @@ const extractDecipher = (body, name, code) => {
   const decipherFunc = getExtractFunction([extractDecipherFunc], body, name, code);
   if (!decipherFunc && !decipherWarning) {
     console.warn(
-      "\x1b[33mWARNING:\x1B[0m Could not parse the decipher function.\n" +
-      `Report this error by uploading the file: "${utils.saveDebugFile("player-script.js", body)}"`
+      "\x1b[33mWARNING:\x1B[0m Could not parse decipher function.\n" +
+      "Stream URLs will be missing.\n" +
+      `Please report this issue by uploading the "${utils.saveDebugFile(
+        "player-script.js",
+        body,
+      )}" file on https://github.com/distubejs/ytdl-core/issues/144.`
     );
     decipherWarning = true;
   }
@@ -282,141 +300,106 @@ const extractDecipher = (body, name, code) => {
 
 const extractNTransform = (body, name, code) => {
   const nTransformFunc = getExtractFunction([extractNTransformFunc], body, name, code);
+
   if (!nTransformFunc && !nTransformWarning) {
     console.warn(
-      "\x1b[33mWARNING:\x1B[0m Could not parse the 'n' transformation function.\n" +
-      `Report this error by uploading the file: "${utils.saveDebugFile("player-script.js", body)}"`
+      "\x1b[33mWARNING:\x1B[0m Could not parse n transform function.\n" +
+      `Please report this issue by uploading the "${utils.saveDebugFile(
+        "player-script.js",
+        body,
+      )}" file on https://github.com/distubejs/ytdl-core/issues/144.`
     );
     nTransformWarning = true;
   }
+
   return nTransformFunc;
 };
 
 exports.extractFunctions = body => {
-  const tceData = extractTceFunc(body);
-  if (!tceData) return [null, null];
-
-  try {
-    // Basic VM test
-    new vm.Script('function test(){}').runInNewContext();
-  } catch (e) {
-    console.error("Error testing functions:", e);
-  }
-
-  return [
-    extractDecipher(body, tceData.name, tceData.code),
-    extractNTransform(body, tceData.name, tceData.code)
-  ];
-};
+  const { name, code } = extractTceFunc(body);
+  return [extractDecipher(body, name, code), extractNTransform(body, name, code)];
+}
 
 exports.setDownloadURL = (format, decipherScript, nTransformScript) => {
   if (!format) return;
 
-  let originalUrl;
-  let hasCipher = false;
+  const decipher = url => {
+    const args = querystring.parse(url);
+    if (!args.s || !decipherScript) return args.url;
 
-  if (format.url) {
-    originalUrl = format.url;
-  } else if (format.signatureCipher || format.cipher) {
-    hasCipher = true;
-    originalUrl = format.signatureCipher || format.cipher;
-  } else {
-    return;
-  }
+    try {
+      const components = new URL(decodeURIComponent(args.url));
+      const context = {};
+      context[DECIPHER_ARGUMENT] = decodeURIComponent(args.s);
+      const decipheredSig = decipherScript.runInNewContext(context);
+
+      components.searchParams.set(args.sp || "sig", decipheredSig);
+      return components.toString();
+    } catch (err) {
+      console.error("Error applying decipher:", err);
+      return args.url;
+    }
+  };
+
+  const nTransform = url => {
+    try {
+      const components = new URL(decodeURIComponent(url));
+      const n = components.searchParams.get("n");
+
+      if (!n || !nTransformScript) return url;
+
+      const context = {};
+      context[N_ARGUMENT] = n;
+      const transformedN = nTransformScript.runInNewContext(context);
+
+      if (transformedN) {
+
+        if (n === transformedN) {
+          console.warn("Transformed n parameter is the same as input, n function possibly short-circuited");
+        } else if (transformedN.startsWith("enhanced_except_") || transformedN.endsWith("_w8_" + n)) {
+          console.warn("N function did not complete due to exception");
+        }
+
+        components.searchParams.set("n", transformedN);
+      } else {
+        console.warn("Transformed n parameter is null, n function possibly faulty");
+      }
+
+      return components.toString();
+    } catch (err) {
+      console.error("Error applying n transform:", err);
+      return url;
+    }
+  };
+
+  const cipher = !format.url;
+  const url = format.url || format.signatureCipher || format.cipher;
+
+  if (!url) return;
 
   try {
-    let finalUrl;
+    format.url = nTransform(cipher ? decipher(url) : url);
 
-    if (hasCipher) {
-      const args = querystring.parse(originalUrl);
-      if (!args.url) return;
-
-      finalUrl = decodeURIComponent(args.url);
-      const urlObj = new URL(finalUrl);
-
-      // --- Signature (sig) ---
-      const sigParamName = args.sp || "sig";
-      if (args.s) {
-        let sigValue = decodeURIComponent(args.s);
-        if (decipherScript) {
-          try {
-            const context = { [DECIPHER_ARGUMENT]: sigValue };
-            const out = decipherScript.runInNewContext(context);
-            if (out) sigValue = out;
-          } catch (e) {
-            console.error("Error deciphering signature:", e);
-          }
-        }
-        urlObj.searchParams.set(sigParamName, sigValue);
-      } else if (args.sig) {
-        urlObj.searchParams.set(sigParamName, args.sig);
-      }
-
-      // --- n Parameter ---
-      if (nTransformScript) {
-        const nParam = urlObj.searchParams.get("n");
-        if (nParam) {
-          try {
-            const context = { [N_ARGUMENT]: nParam };
-            const transformedN = nTransformScript.runInNewContext(context);
-            if (transformedN && transformedN !== nParam) {
-              urlObj.searchParams.set("n", transformedN);
-              console.log(`Transformed n parameter: ${nParam} -> ${transformedN}`);
-            }
-          } catch (e) {
-            console.error("Error transforming n:", e);
-          }
-        }
-      }
-
-      finalUrl = urlObj.toString();
-    } else {
-      // Unencrypted URLs: only n parameter
-      finalUrl = originalUrl;
-      if (nTransformScript) {
-        try {
-          const urlObj = new URL(finalUrl);
-          const nParam = urlObj.searchParams.get("n");
-          if (nParam) {
-            const context = { [N_ARGUMENT]: nParam };
-            const transformedN = nTransformScript.runInNewContext(context);
-            if (transformedN && transformedN !== nParam) {
-              urlObj.searchParams.set("n", transformedN);
-              finalUrl = urlObj.toString();
-              console.log(`Transformed n parameter: ${nParam} -> ${transformedN}`);
-            }
-          }
-        } catch (e) {
-          console.error("Error transforming n on unencrypted URL:", e);
-        }
-      }
-    }
-
-    // Update and clean
-    format.url = finalUrl;
     delete format.signatureCipher;
     delete format.cipher;
-    console.log(`Processed URL: ${finalUrl.substring(0, 100)}...`);
   } catch (err) {
-    console.error("Error processing URL:", err);
+    console.error("Error setting download URL:", err);
   }
 };
 
+/**
+ * Applies decipher and n parameter transforms to all format URL's.
+ *
+ * @param {Array.<Object>} formats
+ * @param {string} html5player
+ * @param {Object} options
+ */
 exports.decipherFormats = async (formats, html5player, options) => {
-  try {
-    const decipheredFormats = {};
-    const [decipherScript, nTransformScript] = await exports.getFunctions(html5player, options);
-
-    formats.forEach(format => {
-      exports.setDownloadURL(format, decipherScript, nTransformScript);
-      if (format.url) {
-        decipheredFormats[format.url] = format;
-      }
-    });
-
-    return decipheredFormats;
-  } catch (err) {
-    console.error("Error deciphering formats:", err);
-    return {};
-  }
+  const decipheredFormats = {};
+  const [decipherScript, nTransformScript] = await exports.getFunctions(html5player, options);
+  formats.forEach(format => {
+    exports.setDownloadURL(format, decipherScript, nTransformScript);
+    decipheredFormats[format.url] = format;
+  });
+  return decipheredFormats;
 };


### PR DESCRIPTION
This PR fixes a `ReferenceError` that happened in the `createProxyAgent` function from `@distube/ytdl-core`. The issue was caused by using a variable named `proxyOptions` that was never defined.

#### What’s changed
* Replaced `proxyOptions` with the existing `options` object that’s already passed into the function.
* This makes sure the `ProxyAgent` is correctly initialized without throwing errors.

#### Before:
```js
const dispatcher = new ProxyAgent(proxyOptions).compose(cookie({ jar }));
```

#### After:
```js
const dispatcher = new ProxyAgent(options).compose(cookie({ jar }));
```

#### Result
No more `ReferenceError`, and the function now sets up the proxy agent properly, working as expected with the rest of DisTube’s request system.

Closes #260
